### PR TITLE
Hide redundant, messy items from page.

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -427,6 +427,10 @@ function calculateBuild(save_skp, skp){
         }
         document.getElementById("level-choice").value = level;
 
+        for (let i of document.getElementsByClassName("hide-container")) {
+			i.style.visibility = "visible";
+		}
+
         console.log(equipment);
         player_build = new Build(level, equipment, powderings);
         console.log(player_build.toString());

--- a/display.js
+++ b/display.js
@@ -103,6 +103,12 @@ function displaySetBonuses(build, parent_id) {
     set_summary_elem.classList.add('itemcenter');
     set_summary_elem.textContent = "Set Bonuses:";
     parent_div.append(set_summary_elem);
+    
+    if (build.activeSetCounts.size) {
+        parent_div.parentElement.style.visibility = "visible";
+    } else {
+        parent_div.parentElement.style.visibility = "hidden";
+    }
 
     for (const [setName, count] of build.activeSetCounts) {
         let set_elem = document.createElement('p');
@@ -1060,9 +1066,9 @@ function displaySpellDamage(parent_elem, overallparent_elem, build, spell, spell
                     results[i][j] = results[i][j].toFixed(2);
                 }
             }
-            let nonCritAverage = (totalDamNormal[0]+totalDamNormal[1])/2;
-            let critAverage = (totalDamCrit[0]+totalDamCrit[1])/2;
-            let averageDamage = (1-critChance)*nonCritAverage+critChance*critAverage;
+            let nonCritAverage = (totalDamNormal[0]+totalDamNormal[1])/2 || 0;
+            let critAverage = (totalDamCrit[0]+totalDamCrit[1])/2 || 0;
+            let averageDamage = (1-critChance)*nonCritAverage+critChance*critAverage || 0;
 
             let averageLabel = document.createElement("p");
             averageLabel.textContent = "Average: "+averageDamage.toFixed(2);

--- a/index.html
+++ b/index.html
@@ -388,13 +388,13 @@
                     </div>
                 </div>
             </div>
-            <div class="build-overall-container">
+            <div class="build-overall-container hide-container" style="visibility: hidden;">
                 <div class = "center build-overall" id = "build-overall">
                     <br/>
                     <div class = "center" id = "build-overall-stats"></div>
                 </div>
             </div>
-            <div class="spell-info-container">
+            <div class="spell-info-container hide-container" style="visibility: hidden;">
                 <div class="spell-info">
                     <div class="center" id="build-melee-statsAvg">melee</div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
             </div>
         </div>
         <div class="misc">
-            <div class = "center set-info" id = "set-info-div" style = "grid-column:1;grid-row:1">
+            <div class = "center set-info" id = "set-info-div" style = "grid-column:1;grid-row:1; visibility: hidden;">
                 <div class = "center" id = "set-info">Set info</div>
             </div>
         </div>


### PR DESCRIPTION
Added hide-container class to both the 'display build' and 'spell info' divs.
Both div elements are hidden by default; and become visible directly before the Build is created(calculateBuild() in builder.js).
This means there is no 
![image](https://user-images.githubusercontent.com/77367421/104396504-b3838e80-559a-11eb-8e08-86a9c5523e18.png)
sitting on the page looking ugly.
