### PR TITLE
Fix atree validator sometimes giving the wrong reason

### DIFF
--- a/js/atree.js
+++ b/js/atree.js
@@ -416,6 +416,7 @@ const atree_validate = new (class extends ComputeNode {
                 reachable.add(ability.id);
             }
             if (atree_to_add.length == _add.length) {
+                atree_to_add = _add;
                 break;
             }
             atree_to_add = _add;


### PR DESCRIPTION
accidentally used reasons from previous iteration


fixes: https://discord.com/channels/819455894890872862/999021989941477407