### PR TITLE
Clear tome inputs in resetFields

### DIFF
--- a/js/builder.js
+++ b/js/builder.js
@@ -60,6 +60,9 @@ function resetFields(){
     for (const i of equipment_inputs) {
         setValue(i, "");
     }
+    for (const i of tomeInputs) {
+        setValue(i, "");
+    }
     setValue("str-skp", "0");
     setValue("dex-skp", "0");
     setValue("int-skp", "0");


### PR DESCRIPTION
This fixes issue #148 by resetting the tome inputs in resetFields (run when the reset button is pressed).