### PR TITLE
Add small desktop layout

### DIFF
--- a/css/sq2bs.css
+++ b/css/sq2bs.css
@@ -193,6 +193,60 @@ input.equipment-input:not(.is-invalid) {
     width: 6.5rem;
 }
 
+@media screen and (orientation: landscape) and (max-width: 1199px) {
+    :root {
+        --scaled-fontsize: 1rem;
+    }
+    .scaled-font {
+        font-size: 1rem;
+    }
+
+    .box-title {
+        font-size: 1rem;
+    }
+
+    .item-title {
+        font-size: 1.2rem;
+    }
+
+    .big-title {
+        font-size: 1.5rem;
+    }
+
+    .skp-tooltip {
+        font-size: 1rem;
+    }
+
+    .spellcost-tooltip b {
+        font-size: .625rem !important;
+    }
+
+    .scaled-item-icon {
+        width: 3.2rem;
+    }
+
+    .scaled-item-icon img {
+        width: 2.8rem;
+    }
+
+    .scaled-bckgrd {
+        width: 4rem;
+        height: 4rem;
+    }
+
+    .scaled-bckgrd img {
+        width: 2.8rem;
+    }
+
+    .warning {
+        font-size: .7rem;
+    }
+
+    .spell-display b {
+        font-size: 1rem;
+    }
+}
+
 @media screen and (min-width: 1200px) and (max-width: 1400px) {
     :root {
         --scaled-fontsize: 1rem;


### PR DESCRIPTION
Hello!

For users with smaller desktops, or those who split screen, the mobile layout is used, but because the user is still on a desktop, the texst is far too big and it is a pain to scroll through everything.

Thus, I have copied the @media selector in sq2bs.css to display the desktop layout when one is using a landscape screen smaller than 1200px (and thus not activating both selectors).
The only difference between the standard desktop layout and the small desktop layout as of now is that .skp-tootip (skill point text) font size has been changed to 1rem to match the standard font size.

The other difference is that bootstrap uses a min-width: 1200px @media selector (and thus does not support small desktop mode), so the UI only has one column in small desktop mode, as opposed to two in standard desktop mode.