### PR TITLE
Remove armor tomes from equip order

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -44,6 +44,12 @@ class Build{
         // calc skillpoints requires statmaps only
         let result = calculate_skillpoints(this.equipment.map((x) => x.statMap), this.weapon.statMap);
         this.equip_order = result[0];
+        for (let i = 0; i < this.equip_order.length; i++) {
+            if (this.equip_order[i].get("type") === "armorTome") {
+                this.equip_order.pop(i);
+                i--;
+            }
+        }
         // How many skillpoints the player had to assign (5 number)
         this.base_skillpoints = result[1];
         // How many skillpoints the build ended up with (5 number)

--- a/js/build.js
+++ b/js/build.js
@@ -43,11 +43,11 @@ class Build{
 
         // calc skillpoints requires statmaps only
         let result = calculate_skillpoints(this.equipment.map((x) => x.statMap), this.weapon.statMap);
-        this.equip_order = result[0];
+        this.equip_order = result[0].slice();
         for (let i = 0; i < this.equip_order.length; i++) {
-            if (this.equip_order[i].get("type") === "armorTome") {
-                this.equip_order.pop(i);
-                i--;
+            if (this.equip_order[i].get("category") === "tome" || this.equip_order[i].get("fixID") === true) {
+                this.equip_order.splice(i, 1);
+		i--;
             }
         }
         // How many skillpoints the player had to assign (5 number)


### PR DESCRIPTION
Hello!

This PR addresses #155 by removing all armour tomes from the shown equip order.

I am not sure why this is an issue, or if it should hide all tomes - but I have addressed the title of the issue.
Please lmk if there is anything else that should be done regarding this.