### PR TITLE
Fix various assassin bugs

### DIFF
--- a/js/atree_constants.js
+++ b/js/atree_constants.js
@@ -6989,7 +6989,7 @@ const atrees = {
                     "display": "Spin Attack",
                     "parts": [
                         {
-                            "name": "Spin Attack",
+                            "name": "Per Hit",
                             "type": "damage",
                             "multipliers": [
                                 120,
@@ -7001,6 +7001,15 @@ const atrees = {
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "add_spell_prop",
+                    "base_spell": 1,
+                    "target_part": "Total Damage",
+                    "hits": {
+                        "Per Hit": 1
+                    },
+                    "display": "Total Damage"
                 }
             ]
         },
@@ -7093,12 +7102,18 @@ const atrees = {
                         "Spin Attack": 1
                     },
                     "display": "Total Damage"
+                },
+                {
+                    "type": "add_spell_prop",
+                    "base_spell": 1,
+                    "target_part": "Per Hit",
+                    "multipliers": [-40, 0, 0, 0, 0, 0]
                 }
             ]
         },
         {
             "display_name": "Poisoned Blade",
-            "desc": "For every 2% or 2 Raw Main Attack Damage you have from items, gain +5/3s Poison Damage (Max 50/3s)",
+            "desc": "For every 2% or 2 Raw Main Attack Damage you have from items, gain +5/3s Poison Damage (Max 50/3s). Your Main Attack gains additional range (+1 Block).",
             "archetype": "Shadestepper",
             "archetype_req": 0,
             "parents": [
@@ -7229,7 +7244,7 @@ const atrees = {
         },
         {
             "display_name": "Smoke Bomb",
-            "desc": "Throw a bomb that slouly emits smoke, damaging all enemies in it every 0.5s.",
+            "desc": "Throw a bomb that slowly emits smoke, damaging all enemies in it every 0.5s.",
             "archetype": "",
             "archetype_req": 0,
             "parents": [
@@ -7750,7 +7765,7 @@ const atrees = {
             "display": {
                 "row": 16,
                 "col": 6,
-                "icon": "node_2"
+                "icon": "node_1"
             },
             "properties": {},
             "effects": []
@@ -7791,7 +7806,7 @@ const atrees = {
         },
         {
             "display_name": "Mirror Image",
-            "desc": "After leaving Vanish, summon 3 Clones that will follow you and protect you. (20s Cooldown)",
+            "desc": "After leaving Vanish, summon 3 Clones that will follow you and protect you (20s Cooldown). When hit, gain a chance to take 80% less damage and lose 1 Clone.",
             "archetype": "Trickster",
             "archetype_req": 2,
             "base_abil": "Dash",
@@ -8161,15 +8176,8 @@ const atrees = {
                 {
                     "type": "add_spell_prop",
                     "base_spell": 1,
-                    "target_part": "Spin Attack",
-                    "multipliers": [
-                        0,
-                        0,
-                        0,
-                        0,
-                        20,
-                        0
-                    ]
+                    "target_part": "Per Hit",
+                    "multipliers": [0, 0, 0, 0, 20, 0]
                 }
             ]
         },
@@ -10416,7 +10424,7 @@ const atrees = {
             "display_name": "Masquerade",
             "desc": "After switching from a Mask to another 2 times, gain 30 mana.",
             "base_abil": "Uproot",
-          	"archetype": "Ritualist",
+            "archetype": "Ritualist",
             "parents": ["Mask of the Fanatic"],
             "dependencies": ["Mask of the Lunatic"],
             "blockers": [],
@@ -10496,7 +10504,7 @@ const atrees = {
             "display_name": "Storm Dance",
             "desc": "Enemies hit by Aura will be pulled towards your totem.",
             "base_abil": "Aura",
-          	"archetype": "Ritualist",
+            "archetype": "Ritualist",
             "parents": ["Cheaper Totem II", "Mask of the Fanatic", "Blood Moon"],
             "dependencies": ["Aura"],
             "blockers": [],
@@ -10508,12 +10516,12 @@ const atrees = {
             },
             "properties": {},
             "effects": [
-              	{
+                {
                 "type": "add_spell_prop",
                 "base_spell": 3,
                 "target_part": "Single Wave",
                 "multipliers": [0, 0, 0, 0, 0, 30]
-            	}
+                }
             ]
         },
         {
@@ -10571,14 +10579,14 @@ const atrees = {
                 "cost": -5
             }]
         },
-      	{
+        {
             "display_name": "Cheaper Aura II",
             "desc": "Reduce the Mana cost of Aura.",
             "base_abil": "Aura",
             "parents": [
                 "Double Totem",
                 "Cheaper Totem II",
-              	"Seeking Totem"
+                "Seeking Totem"
             ],
             "dependencies": ["Aura"],
             "blockers": [],
@@ -10595,11 +10603,11 @@ const atrees = {
                 "cost": -5
             }]
         },
-      	{
+        {
             "display_name": "Seeking Totem",
             "desc": "When wearing the Mask of the Fanatic, your Totem will move towards the nearest enemy outside of its range.",
             "base_abil": "Totem",
-          	"archetype": "Ritualist",
+            "archetype": "Ritualist",
             "parents": [
                 "Storm Dance",
                 "Cheaper Totem II"
@@ -10609,16 +10617,16 @@ const atrees = {
             "cost": 2,
             "display": {
                 "row": 26,
-              	"col": 4,
+                "col": 4,
                 "icon": "node_1"
             },
             "properties": {},
             "effects": []
         },
-      	{
+        {
             "display_name": "Twisted Tether",
             "desc": "When hitting an enemy with your Main Attack, use 1% from your Blood Pool and add Tether to them. Tethered enemies will take damage for every 2% Health you lose. (Max 10%)",
-          	"archetype": "Acolyte",
+            "archetype": "Acolyte",
             "archetype_req": 7,
             "parents": [
                 "Storm Dance",
@@ -10629,12 +10637,12 @@ const atrees = {
             "cost": 2,
             "display": {
                 "row": 26,
-              	"col": 7,
+                "col": 7,
                 "icon": "node_3"
             },
             "properties": {},
             "effects": [
-              	{
+                {
                     "type": "replace_spell",
                     "name": "Twisted Tether",
                     "base_spell": 6,
@@ -10653,13 +10661,13 @@ const atrees = {
                 }
             ]
         },
-      	{
+        {
             "display_name": "Stronger Totem",
             "desc": "Increase Totem's damage.",
             "base_abil": "Totem",
             "parents": [
                 "Cheaper Aura II",
-              	"Seeking Totem"
+                "Seeking Totem"
             ],
             "dependencies": ["Totem"],
             "blockers": [],
@@ -10671,15 +10679,15 @@ const atrees = {
             },
             "properties": {},
             "effects": [
-              	{
+                {
                     "type": "add_spell_prop",
                     "base_spell": 1,
                     "target_part": "Tick Damage",
                     "multipliers": [4, 0, 0, 0, 0, 0]
-            	}
+                }
             ]
         },
-      	{
+        {
             "display_name": "Depersonalization",
             "desc": "Masquerade will need -1 Mask switch to trigger. Reduce the mana given by -10.",
             "archetype": "Ritualist",
@@ -10903,11 +10911,11 @@ const atrees = {
                 }
             ]
         },
-		{
+        {
             "display_name": "Chant of the Coward",
             "desc": "When switching to the Mask of the Coward, damage and knockback nearby enemies.",
             "archetype": "Ritualist",
-          	"archetype_req": 7,
+            "archetype_req": 7,
             "parents": ["Fluid Healing", "Mask of the Coward"],
             "dependencies": ["Mask of the Coward"],
             "blockers": [],
@@ -10919,7 +10927,7 @@ const atrees = {
             },
             "properties": { "aoe": 8 },
             "effects": [
-              	{
+                {
                     "type": "add_spell_prop",
                     "target_part": "Chant of the Coward",
                     "base_spell": 4,
@@ -10928,11 +10936,11 @@ const atrees = {
                 }
             ]
         },     
-		{
+        {
             "display_name": "Blood Rite",
             "desc": "When yourself or an ally gets hit while standing in your Totem's range, add 25% of the damage taken into your Blood Pool. (Max 10%)",
             "archetype": "Acolyte",
-          	"archetype_req": 9,
+            "archetype_req": 9,
             "parents": ["Fluid Healing", "More Blood Pool II"],
             "dependencies": ["Sacrificial Shrine"],
             "blockers": [],
@@ -10945,11 +10953,11 @@ const atrees = {
             "properties": {},
             "effects": []
         },
-		{
+        {
             "display_name": "More Effigies",
             "desc": "Increase your Max Effigies by +1.",
             "archetype": "Summoner",
-          	"archetype_req": 8,
+            "archetype_req": 8,
             "base_abil": "Crimson Effigy",
             "parents": ["Maddening Roots"],
             "dependencies": ["Crimson Effigy"],
@@ -10983,7 +10991,7 @@ const atrees = {
             "properties": {},
             "effects": []
         },
-		{
+        {
             "display_name": "Stronger Tether",
             "desc": "Increase Twisted Tether's damage.",
             "archetype": "Acolyte",
@@ -10998,12 +11006,12 @@ const atrees = {
             },
             "properties": {},
             "effects": [
-              	{
+                {
                     "type": "add_spell_prop",
                     "base_spell": 6,
                     "target_part": "Tether Tick",
                     "multipliers": [10, 0, 0, 0, 0, 0]
-            	}
+                }
             ]
         },
         {
@@ -11075,7 +11083,7 @@ const atrees = {
                 }
             ]
         },
-		{
+        {
             "display_name": "Mengdu",
             "desc": "For every 1% Thorns you have from item IDs, gain +1% Water Damage. (Max 100%)",
             "parents": ["Chant of the Fanatic", "Invigorating Wave"],
@@ -11107,7 +11115,7 @@ const atrees = {
                 }
             ]
         },
-		{
+        {
             "display_name": "Frog Dance",
             "desc": "When wearing the Mask of the Coward, Haul will make you bounce off the ground 3 times at increasing speed and deal damage to nearby enemies.",
             "archetype": "Ritualist",
@@ -11123,19 +11131,19 @@ const atrees = {
             },
             "properties": {},
             "effects": [
-              	{
+                {
                     "type": "add_spell_prop",
                     "base_spell": 2,
                     "target_part": "Hop Damage",
                     "multipliers": [90, 0, 0, 30, 0, 0]
-            	},
-              	{
+                },
+                {
                     "type": "add_spell_prop",
                     "base_spell": 2,
                     "target_part": "Total Damage",
                     "hits": { "Hop Damage": 3 },
                     "display": "Total Damage"
-            	},
+                },
                 {
                     "type": "raw_stat",
                     "bonuses": [{
@@ -11155,7 +11163,7 @@ const atrees = {
                 }
             ]
         },
-		{
+        {
             "display_name": "More Blood Pool III",
             "desc": "Increase your maximum Blood pool by +30%.",
             "archetype": "Acolyte",
@@ -11172,7 +11180,7 @@ const atrees = {
             "properties": {"blood_pool": 30},
             "effects": []
         },
-		{
+        {
             "display_name": "Shepherd",
             "desc": "When you or your Summons kill an enemy, gain +1 Max Puppets for 20s. (Max +10)",
             "archetype": "Summoner",
@@ -11209,7 +11217,7 @@ const atrees = {
                 }
             ]
         },
-      	{
+        {
             "display_name": "Mask of the Awakened",
             "desc": "After saving 200 Mana from your Masks' mana reductions, casting Uproot will make you wear the Mask of the Awakened for 20s, giving the power of all Masks at once.",
             "base_abil": "Uproot",
@@ -11237,12 +11245,12 @@ const atrees = {
                     "type": "raw_stat",
                     "toggle": "Mask of the Awakened",
                     "bonuses": [
-                      	{
+                        {
                             "type": "stat",
                             "name": "damMult.Mask",
                             "value": 30
                         },
-                      	{
+                        {
                             "type": "stat",
                             "name": "defMult.Mask",
                             "value": 30
@@ -11262,7 +11270,7 @@ const atrees = {
                             "name": "spPct2Final",
                             "value": -50
                         },
-                      	{
+                        {
                             "type": "stat",
                             "name": "spPct3Final",
                             "value": -30
@@ -11288,7 +11296,7 @@ const atrees = {
             },
             "properties": {},
             "effects": [
-              	{
+                {
                     "type": "replace_spell",
                     "name": "Blood Sorrow",
                     "base_spell": 8,
@@ -11298,7 +11306,7 @@ const atrees = {
                             "name": "Beam Tick Damage",
                             "multipliers": [70, 0, 0, 20, 0, 0]
                         },
-                      	{
+                        {
                             "name": "Beam DPS",
                             "hits": {
                                 "Beam Tick Damage": 5
@@ -11314,7 +11322,7 @@ const atrees = {
                 }
             ]
         },
-      	{
+        {
             "display_name": "Cheaper Uproot II",
             "desc": "Reduce the Mana cost of Uproot.",
             "base_abil": "Uproot",


### PR DESCRIPTION
- Double Spin: wasn't adding a second hit and didn't have spell mult reduction
- Poisoned Blade: didn't have increased main attack range in description
- Smoke Bomb: fixed spelling error "slouly" -> "slowly"
- Righting Reflex: fixed sprite "node_2" -> "node_1"
- Mirror Image: added damage reduction to description
- Blazing Powder: fixed (?) so that it interacts with Lacerate correctly (should apply to each hit)