### PR TITLE
WynnCustom Item Display Fix

### DIFF
--- a/js/customizer.js
+++ b/js/customizer.js
@@ -181,7 +181,7 @@ function calculateCustom() {
         player_custom_item.setHash(custom_str);
 
         
-        displaysq2ExpandedItem(player_custom_item.statMap, "custom-stats");
+        displayExpandedItem(player_custom_item.statMap, "custom-stats");
 
     }catch (error) {
         //The error elements no longer exist in the page. Add them back if needed.


### PR DESCRIPTION
displaysq2ExpandedItem is undefined. Replacing it with displayExpandedItem (defined in display.js) works.