### PR TITLE
Remove "air gap" nodes

### DIFF
--- a/builder/doc.html
+++ b/builder/doc.html
@@ -1314,13 +1314,13 @@
     <script type="text/javascript" src="../js/load_tome.js"></script>
     <script type="text/javascript" src="../js/custom.js"></script> 
     <script type="text/javascript" src="../js/craft.js"></script>  
-    <script type="text/javascript" src="../js/builder/atree_constants_min.js"></script>
     <script type="text/javascript" src="../js/builder/build.js"></script>
     <script type="text/javascript" src="../js/builder/builder_constants.js"></script>
     <script type="text/javascript" src="../js/builder/build_encode_decode.js"></script>
     <script type="text/javascript" src="../js/builder/atree.js"></script>
-    <script type="text/javascript" src="../js/builder/builder.js"></script>
     <script type="text/javascript" src="../js/builder/builder_graph.js"></script>
+    <script type="text/javascript" src="../js/builder/builder.js"></script>
+    <!--script type="text/javascript" src="../js/builder/optimize.js"></script-->
 
     <div id="graph_body" style="max-width: 100%; height: 100vh">
         <button id="saveButton">JANKY Export SVG</button>

--- a/js/builder/build_encode_decode.js
+++ b/js/builder/build_encode_decode.js
@@ -53,6 +53,7 @@ async function parse_hash(url_tag) {
     let powdering = ["", "", "", "", ""];
     let info = url_tag.split("_");
     let version = info[0];
+    // Whether skillpoints are manually updated. True if they should be set to something other than default values
     let save_skp = false;
     let skillpoints = [0, 0, 0, 0, 0];
     let level = 106;
@@ -157,7 +158,9 @@ async function parse_hash(url_tag) {
     }
 
     //level, skill point assignments, and powdering
-    if (version_number == 1) {
+    if (version_number == 0) {
+        // do nothing! lol
+    } else if (version_number == 1) {
         let powder_info = data_str;
         let res = parsePowdering(powder_info);
         powdering = res[0];
@@ -222,6 +225,8 @@ async function parse_hash(url_tag) {
     for (let i in skillpoints) {
         setValue(skp_order[i] + "-skp", skillpoints[i]);
     }
+
+    return save_skp;
 }
 
 /*  Stores the entire build in a string using B64 encoding and adds it to the URL.

--- a/js/builder/builder.js
+++ b/js/builder/builder.js
@@ -358,14 +358,16 @@ async function init() {
         });
     } catch (e) {
         console.log("Could not initialize macy components. Maybe you're offline?");
+        console.log(e);
     }
-    await parse_hash(url_tag);
+    const save_skp = await parse_hash(url_tag);
     try {
         init_autocomplete();
     } catch (e) {
         console.log("Could not initialize autocomplete. Maybe you're offline?");
+        console.log(e);
     }
-    builder_graph_init();
+    builder_graph_init(save_skp);
     for (const item_node of item_nodes) {
         if (item_node.get_value() === null) {
             // likely DB load failure...

--- a/js/builder/builder_graph.js
+++ b/js/builder/builder_graph.js
@@ -937,8 +937,7 @@ class AggregateEditableIDNode extends ComputeNode {
 
 let edit_id_output;
 function resetEditableIDs() {
-    edit_id_output.mark_dirty();
-    edit_id_output.update();
+    edit_id_output.mark_dirty().update();
     edit_id_output.notify();
 }
 /**
@@ -998,6 +997,11 @@ class SkillPointSetterNode extends ComputeNode {
         for (const [idx, elem] of skp_order.entries()) {
             document.getElementById(elem+'-skp').value = build.total_skillpoints[idx];
         }
+        for (const child of this.notify_nodes) {
+            console.log(child.inputs_dirty, child.dirty);
+        }
+        console.log("set skp");
+        console.log(build.total_skillpoints);
     }
 }
 
@@ -1042,7 +1046,11 @@ let stat_agg_node;
 let edit_agg_node;
 let atree_graph_creator;
 
-function builder_graph_init() {
+/**
+ * Parameters:
+ *  save_skp:   bool    True if skillpoints are modified away from skp engine defaults.
+ */
+function builder_graph_init(save_skp) {
     // Phase 1/3: Set up item input, propagate updates, etc.
 
     // Level input node.
@@ -1201,6 +1209,9 @@ function builder_graph_init() {
 
     let skp_output = new SkillPointSetterNode(skp_inputs);
     skp_output.link_to(build_node);
+    if (!save_skp) {
+        skp_output.update().mark_dirty().update();
+    }
 
     let build_warnings_node = new DisplayBuildWarningsNode();
     build_warnings_node.link_to(build_node, 'build');

--- a/js/builder/builder_graph.js
+++ b/js/builder/builder_graph.js
@@ -955,7 +955,6 @@ class EditableIDSetterNode extends ComputeNode {
     }
 
     compute_func(input_map) {
-        console.log("flush editable IDs");
         if (input_map.size !== 1) { throw "EditableIDSetterNode accepts exactly one input (build)"; }
         const [build] = input_map.values();  // Extract values, pattern match it into size one list and bind to first element
         for (const id of editable_item_fields) {
@@ -997,11 +996,6 @@ class SkillPointSetterNode extends ComputeNode {
         for (const [idx, elem] of skp_order.entries()) {
             document.getElementById(elem+'-skp').value = build.total_skillpoints[idx];
         }
-        for (const child of this.notify_nodes) {
-            console.log(child.inputs_dirty, child.dirty);
-        }
-        console.log("set skp");
-        console.log(build.total_skillpoints);
     }
 }
 

--- a/js/computation_graph.js
+++ b/js/computation_graph.js
@@ -30,10 +30,10 @@ class ComputeNode {
      */
     update() {
         if (this.inputs_dirty_count != 0) {
-            return;
+            return this;
         }
         if (this.dirty === 0) {
-            return;
+            return this;
         }
         if (COMPUTE_GRAPH_DEBUG) { node_debug_stack.push(this.name); }
         if (this.dirty == 2) {
@@ -150,10 +150,10 @@ class ValueCheckComputeNode extends ComputeNode {
      */
     update() {
         if (this.inputs_dirty_count != 0) {
-            return;
+            return this;
         }
         if (this.dirty === 0) {
-            return;
+            return this;
         }
 
         let calc_inputs = new Map();

--- a/js/computation_graph.js
+++ b/js/computation_graph.js
@@ -179,7 +179,6 @@ class ValueCheckComputeNode extends ComputeNode {
     mark_dirty(dirty_state="unused") {
         return super.mark_dirty(1);
     }
-
 }
 
 let graph_live_update = false;
@@ -196,8 +195,10 @@ function calcSchedule(node, timeout) {
     node.mark_dirty();
     node.update_task = setTimeout(function() {
         if (COMPUTE_GRAPH_DEBUG) { node_debug_stack = []; }
+        graph_live_update = false;
         node.update();
         node.update_task = null;
+        graph_live_update = true;
     }, timeout);
 }
 

--- a/js/load.js
+++ b/js/load.js
@@ -208,11 +208,6 @@ async function load_init() {
     });
 }
 
-// List of 'raw' "none" items (No Helmet, etc), in order helmet, chestplate... ring1, ring2, brace, neck, weapon.
-for (const it of item_types) {
-    itemLists.set(it, []);
-}
-
 let none_items = [
     ["armor", "helmet", "No Helmet"],
     ["armor", "chestplate", "No Chestplate"],
@@ -251,7 +246,11 @@ for (let i = 0; i < none_items.length; i++) {
 }
 
 function init_maps() {
-    //warp
+    // List of 'raw' "none" items (No Helmet, etc), in order helmet, chestplate... ring1, ring2, brace, neck, weapon.
+    for (const it of item_types) {
+        itemLists.set(it, []);
+    }
+
     itemMap = new Map();
     /* Mapping from item names to set names. */
     idMap = new Map();


### PR DESCRIPTION
they... just aren't necessary... compute graph supports having inputs in the middle anyway WHY did I do this in the past (and it caused issues with dusty update)

Fixes hanging bugs observed with empty item slots / empty tome slots