### PR TITLE
Cleaning out duplication in compute_graph

### DIFF
--- a/js/computation_graph.js
+++ b/js/computation_graph.js
@@ -3,6 +3,12 @@ let node_debug_stack = [];
 let COMPUTE_GRAPH_DEBUG = true;
 
 class NodeInput {
+    /**
+    * @property {ComputeNode} node - the actual parent node.
+    * @property {string} translation - translation for some nodes. equals to node.name if no special handling is required.
+    * @property {boolean} is_dirty - flag indicating whether the input was already marked dirty. Important when a node has
+    * multiple simultanious update paths.
+    */
     constructor(node, translation=node.name) {
         this.node = node;
         this.translation = translation;

--- a/js/debug/render_compute_graph.js
+++ b/js/debug/render_compute_graph.js
@@ -78,10 +78,9 @@ function convert_data(nodes_raw) {
     }
     for (const node of nodes_raw) {
         const to = node_id.get(node);
-        for (const input of node.inputs) {
-            const from = node_id.get(input);
-            let name = input.name;
-            let link_name = node.input_translation.get(name);
+        for (const input of node.inputs.values()) {
+            const from = node_id.get(input.node);
+            let link_name = input.translation;
             edges.push({
                 source: from,
                 target: to,


### PR DESCRIPTION
Condenses the multiple maps in ComputeNode (input_translation, inputs_dirty) into a single NodeInput that contains the node, translation and an is_dirty flag (Originally I intended to remove this flag, then I understood that it's necessary because of nodes with multiple update paths incorrectly increasing the dirty_count multiple times).

This _should_ improve overall performance and memory? not entirely sure how to profile this
It almost definitely improves remove_link performance because of no longer needing to do O(n) lookup and Map.delete from input_translation and inputs_dirty. (M forgot to remove the comment)

To note - I thought about converting children to a Map aswell in favor of remove_link, but because remove link is used rather rarely it seemed like that would do more damage than good. If it is beneficial the change is trivial.

Closes #38 